### PR TITLE
fix: missing role on passport

### DIFF
--- a/src/config/passport.ts
+++ b/src/config/passport.ts
@@ -17,7 +17,8 @@ const jwtVerify: VerifyCallback = async (payload, done) => {
       select: {
         id: true,
         email: true,
-        name: true
+        name: true,
+        role: true
       },
       where: { id: payload.sub }
     });


### PR DESCRIPTION
here is a missing role in the Passport configuration, which will affect the `verifyCallback` function in the `auth.ts` file. This function relies on obtaining `userRights` based on the user's role.