### PR TITLE
fix skip value in queryUsers

### DIFF
--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -63,7 +63,7 @@ const queryUsers = async <Key extends keyof User>(
   const users = await prisma.user.findMany({
     where: filter,
     select: keys.reduce((obj, k) => ({ ...obj, [k]: true }), {}),
-    skip: page * limit,
+    skip: (page - 1) * limit,
     take: limit,
     orderBy: sortBy ? { [sortBy]: sortType } : undefined
   });


### PR DESCRIPTION
## Issue

- the `skip` value is calculated with `page * limit` which would skip the first `limit` records for page 1

## Fix

```
skip: (page - 1) * limit
```

Thank you for the template, it's been helpful! 👍 

