### PR TITLE
fix: authorization can not get role

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,10 @@
 PORT=3000
 
 # Postgres URL
-DATABASE_URL="postgresql://postgres:secret@localhost:5432/mydb?schema=public"
+POSTGRES_USER=username
+POSTGRES_PASSWORD=secret
+POSTGRES_DB=mydb
+DATABASE_URL="postgresql://username:secret@localhost:5432/mydb?schema=public"
 
 # JWT
 # JWT secret key

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:alpine
+FROM node:20-slim
+RUN apt-get update
+RUN apt-get install -y openssl
 
 RUN mkdir -p /usr/src/node-app && chown -R node:node /usr/src/node-app
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,4 +3,4 @@ version: '3.8'
 services:
   node-app:
     container_name: node-app-dev
-    command: yarn dev -L
+    command: sh -c "yarn prisma generate && yarn db:push --accept-data-loss && yarn dev -L"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,5 +3,4 @@ version: '3.8'
 services:
   node-app:
     container_name: node-app-prod
-    command: yarn start
-
+    command: sh -c "yarn prisma generate && yarn db:push && yarn start"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,13 @@ services:
   node-app:
     build: .
     image: node-app
+    environment:
+      - REDIS_HOST=redis
     ports:
       - '3000:3000'
     depends_on:
       - postgresdb
+      - redis
     volumes:
       - .:/usr/src/node-app
     networks:
@@ -17,8 +20,9 @@ services:
     image: postgres
     restart: always
     environment:
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=secret
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
     ports:
       - '5432:5432'
     volumes:
@@ -26,8 +30,21 @@ services:
     networks:
       - node-network
 
+  redis:
+    image: redis:alpine
+    restart: always
+    ports:
+      - '6379:6379'
+    volumes:
+      - redis_data:/data
+    command: redis-server --appendonly yes
+    networks:
+      - node-network
+
 volumes:
   dbdata:
+    driver: local
+  redis_data:
     driver: local
 
 networks:

--- a/src/config/passport.ts
+++ b/src/config/passport.ts
@@ -17,7 +17,8 @@ const jwtVerify: VerifyCallback = async (payload, done) => {
       select: {
         id: true,
         email: true,
-        name: true
+        name: true,
+        role: true
       },
       where: { id: payload.sub }
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -779,10 +779,10 @@
   resolved "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.7.1-1.272861e07ab64f234d3ffc4094e32bd61775599c.tgz"
   integrity sha512-Bd4LZ+WAnUHOq31e9X/ihi5zPlr4SzTRwUZZYxvWOxlerIZ7HJlVa9zXpuKTKLpI9O1l8Ec4OYCKsivWCs5a3Q==
 
-"@prisma/engines@4.10.1":
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-4.10.1.tgz#c7062747f254e5d5fce98a8cae566c25f9f29fb2"
-  integrity sha512-B3tcTxjx196nuAu1GOTKO9cGPUgTFHYRdkPkTS4m5ptb2cejyBlH9X7GOfSt3xlI7p4zAJDshJP4JJivCg9ouA==
+"@prisma/engines@4.16.2":
+  version "4.16.2"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-4.16.2.tgz#5ec8dd672c2173d597e469194916ad4826ce2e5f"
+  integrity sha512-vx1nxVvN4QeT/cepQce68deh/Turxy5Mr+4L4zClFuK1GlxN3+ivxfuv+ej/gvidWn1cE1uAhW7ALLNlYbRUAw==
 
 "@sideway/address@^4.1.3":
   version "4.1.4"
@@ -4282,12 +4282,12 @@ pretty-format@^29.0.0, pretty-format@^29.3.1:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
-prisma@^4.7.1:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/prisma/-/prisma-4.10.1.tgz#88084695d7b364ae6bebf93d5006f84439c4e7d1"
-  integrity sha512-0jDxgg+DruB1kHVNlcspXQB9au62IFfVg9drkhzXudszHNUAQn0lVuu+T8np0uC2z1nKD5S3qPeCyR8u5YFLnA==
+prisma@^4.10.1:
+  version "4.16.2"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-4.16.2.tgz#469e0a0991c6ae5bcde289401726bb012253339e"
+  integrity sha512-SYCsBvDf0/7XSJyf2cHTLjLeTLVXYfqp7pG5eEVafFLeT0u/hLFz/9W196nDRGUOo1JfPatAEb+uEnTQImQC1g==
   dependencies:
-    "@prisma/engines" "4.10.1"
+    "@prisma/engines" "4.16.2"
 
 promptly@^2:
   version "2.2.0"


### PR DESCRIPTION
When using the `auth('getUsers')` or other authorization functions, I noticed that it returns a 403 error when my role is set to `ADMIN`. After investigating further, I discovered that the issue lies within the `jwtVerify` function in `src/config/passport.ts`, which fails to retrieve roles from the database.